### PR TITLE
[CI debug — do not merge] Instrument widgets test timings on windows

### DIFF
--- a/examples/example-dockpanel/src/index.ts
+++ b/examples/example-dockpanel/src/index.ts
@@ -301,7 +301,7 @@ function main(): void {
   bar.addMenu(emptyMenu);
   bar.id = 'menuBar';
 
-  let palette = new CommandPalette({ commands });
+  let palette = new CommandPalette({ commands, maxRecentCommands: 3 });
   palette.addItem({ command: 'example:cut', category: 'Edit' });
   palette.addItem({ command: 'example:copy', category: 'Edit' });
   palette.addItem({ command: 'example:paste', category: 'Edit' });

--- a/packages/widgets/src/commandpalette.ts
+++ b/packages/widgets/src/commandpalette.ts
@@ -41,6 +41,7 @@ export class CommandPalette extends Widget {
     this.setFlag(Widget.Flag.DisallowLayout);
     this.commands = options.commands;
     this.renderer = options.renderer || CommandPalette.defaultRenderer;
+    this.maxRecentCommands = options.maxRecentCommands ?? 0;
     this.commands.commandChanged.connect(this._onGenericChange, this);
     this.commands.keyBindingChanged.connect(this._onGenericChange, this);
   }
@@ -50,6 +51,7 @@ export class CommandPalette extends Widget {
    */
   dispose(): void {
     this._items.length = 0;
+    this._recentCommands.length = 0;
     this._results = null;
     super.dispose();
   }
@@ -107,6 +109,46 @@ export class CommandPalette extends Widget {
    */
   get items(): ReadonlyArray<CommandPalette.IItem> {
     return this._items;
+  }
+
+  /**
+   * The maximum number of recently executed commands to display.
+   *
+   * #### Notes
+   * When the limit is positive, the most recently executed commands
+   * are displayed at the top of the palette when the search query is
+   * empty. When searching, the results are ordered as usual and the
+   * recently executed commands are only marked as recent.
+   *
+   * Setting the limit to `0` disables the tracking and display of the
+   * recently executed commands, and clears the existing history.
+   *
+   * Setting the limit to a value smaller than the current history
+   * drops the oldest commands from the history.
+   */
+  get maxRecentCommands(): number {
+    return this._maxRecentCommands;
+  }
+
+  set maxRecentCommands(value: number) {
+    // Normalize the limit to a non-negative integer, coercing `NaN` to `0`.
+    value = Math.max(0, Math.floor(value)) || 0;
+
+    // Bail if the limit does not change.
+    if (this._maxRecentCommands === value) {
+      return;
+    }
+
+    // Update the limit.
+    this._maxRecentCommands = value;
+
+    // Drop the oldest commands which exceed the new limit.
+    if (this._recentCommands.length > value) {
+      this._recentCommands.length = value;
+    }
+
+    // Refresh the search results.
+    this.refresh();
   }
 
   /**
@@ -188,6 +230,22 @@ export class CommandPalette extends Widget {
 
     // Clear the array of items.
     this._items.length = 0;
+
+    // Refresh the search results.
+    this.refresh();
+  }
+
+  /**
+   * Clear the recently executed commands.
+   */
+  clearRecentCommands(): void {
+    // Bail if there is nothing to remove.
+    if (this._recentCommands.length === 0) {
+      return;
+    }
+
+    // Clear the array of recently executed commands.
+    this._recentCommands.length = 0;
 
     // Refresh the search results.
     this.refresh();
@@ -309,7 +367,11 @@ export class CommandPalette extends Widget {
     let results = this._results;
     if (!results) {
       // Generate and store the new search results.
-      results = this._results = Private.search(this._items, query);
+      results = this._results = Private.search(
+        this._items,
+        query,
+        this._recentCommands
+      );
 
       // Reset the active index.
       this._activeIndex = query
@@ -344,7 +406,8 @@ export class CommandPalette extends Widget {
         let item = result.item;
         let indices = result.indices;
         let active = i === activeIndex;
-        content[i] = renderer.renderItem({ item, indices, active });
+        let recent = result.recent;
+        content[i] = renderer.renderItem({ item, indices, active, recent });
       }
     }
 
@@ -502,11 +565,40 @@ export class CommandPalette extends Widget {
     // Execute the item.
     this.commands.execute(part.item.command, part.item.args);
 
+    // Add the item to the recently executed commands.
+    this._addRecentCommand(part.item);
+
     // Clear the query text.
     this.inputNode.value = '';
 
     // Refresh the search results.
     this.refresh();
+  }
+
+  /**
+   * Add a command item to the recently executed commands.
+   */
+  private _addRecentCommand(item: CommandPalette.IItem): void {
+    // Bail if recently executed commands are not tracked.
+    if (this._maxRecentCommands === 0) {
+      return;
+    }
+
+    // Remove any existing entry for the command.
+    ArrayExt.removeFirstWhere(this._recentCommands, recent => {
+      return (
+        recent.command === item.command &&
+        JSONExt.deepEqual(recent.args, item.args)
+      );
+    });
+
+    // Add the command to the front of the history.
+    this._recentCommands.unshift({ command: item.command, args: item.args });
+
+    // Drop the oldest command if the history exceeds the limit.
+    if (this._recentCommands.length > this._maxRecentCommands) {
+      this._recentCommands.length = this._maxRecentCommands;
+    }
   }
 
   /**
@@ -527,6 +619,8 @@ export class CommandPalette extends Widget {
   private _activeIndex = -1;
   private _items: CommandPalette.IItem[] = [];
   private _results: Private.SearchResult[] | null = null;
+  private _maxRecentCommands = 0;
+  private _recentCommands: Private.IRecentCommand[] = [];
 }
 
 /**
@@ -548,6 +642,22 @@ export namespace CommandPalette {
      * The default is a shared renderer instance.
      */
     renderer?: IRenderer;
+
+    /**
+     * The maximum number of recently executed commands to display.
+     *
+     * #### Notes
+     * When the limit is positive, the most recently executed commands
+     * are displayed at the top of the palette when the search query is
+     * empty. When searching, the results are ordered as usual and the
+     * recently executed commands are only marked as recent.
+     *
+     * When the limit is `0`, recently executed commands are neither
+     * tracked nor displayed.
+     *
+     * The default value is `0`.
+     */
+    maxRecentCommands?: number;
   }
 
   /**
@@ -707,6 +817,14 @@ export namespace CommandPalette {
      * Whether the item is the active item.
      */
     readonly active: boolean;
+
+    /**
+     * Whether the item is a recently executed command.
+     *
+     * #### Notes
+     * The default value is `false`.
+     */
+    readonly recent?: boolean;
   }
 
   /**
@@ -903,6 +1021,9 @@ export namespace CommandPalette {
       if (data.active) {
         name += ' lm-mod-active';
       }
+      if (data.recent) {
+        name += ' lm-mod-recent';
+      }
 
       // Add the extra class.
       let extra = data.item.className;
@@ -1048,6 +1169,21 @@ namespace Private {
   }
 
   /**
+   * An object which represents a recently executed command.
+   */
+  export interface IRecentCommand {
+    /**
+     * The command which was executed.
+     */
+    readonly command: string;
+
+    /**
+     * The arguments for the command.
+     */
+    readonly args: ReadonlyJSONObject;
+  }
+
+  /**
    * A search result object for a header label.
    */
   export interface IHeaderResult {
@@ -1085,6 +1221,11 @@ namespace Private {
      * The indices of the matched label characters.
      */
     readonly indices: ReadonlyArray<number> | null;
+
+    /**
+     * Whether the item is a recently executed command.
+     */
+    readonly recent?: boolean;
   }
 
   /**
@@ -1097,16 +1238,20 @@ namespace Private {
    */
   export function search(
     items: CommandPalette.IItem[],
-    query: string
+    query: string,
+    recentCommands: ReadonlyArray<IRecentCommand>
   ): SearchResult[] {
+    // Resolve the recently executed commands to their items.
+    let recentItems = resolveRecentItems(items, recentCommands);
+
     // Fuzzy match the items for the query.
-    let scores = matchItems(items, query);
+    let scores = matchItems(items, query, recentItems);
 
     // Sort the items based on their score.
     scores.sort(scoreCmp);
 
     // Create the results for the search.
-    return createResults(scores);
+    return createResults(scores, recentItems);
   }
 
   /**
@@ -1134,6 +1279,7 @@ namespace Private {
    * An enum of the supported match types.
    */
   const enum MatchType {
+    Recent,
     Label,
     Category,
     Split,
@@ -1171,14 +1317,66 @@ namespace Private {
   }
 
   /**
+   * Resolve recently executed commands to their command items.
+   */
+  function resolveRecentItems(
+    items: CommandPalette.IItem[],
+    recentCommands: ReadonlyArray<IRecentCommand>
+  ): CommandPalette.IItem[] {
+    // Set up the array of resolved items.
+    let recentItems: CommandPalette.IItem[] = [];
+
+    // Iterate over the recently executed commands.
+    for (let recent of recentCommands) {
+      // Find the item for the command, if any.
+      let item = ArrayExt.findFirstValue(items, candidate => {
+        return (
+          candidate.command === recent.command &&
+          JSONExt.deepEqual(candidate.args, recent.args)
+        );
+      });
+
+      // Ignore commands which do not resolve to a visible and enabled
+      // item. A disabled item cannot be executed again, so it is listed
+      // in its own category instead until it is enabled again.
+      if (item && item.isVisible && item.isEnabled) {
+        recentItems.push(item);
+      }
+    }
+
+    // Return the resolved items.
+    return recentItems;
+  }
+
+  /**
    * Perform a fuzzy match on an array of command items.
    */
-  function matchItems(items: CommandPalette.IItem[], query: string): IScore[] {
+  function matchItems(
+    items: CommandPalette.IItem[],
+    query: string,
+    recentItems: CommandPalette.IItem[]
+  ): IScore[] {
     // Normalize the query text to lower case with no whitespace.
     query = normalizeQuery(query);
 
     // Create the array to hold the scores.
     let scores: IScore[] = [];
+
+    // For an empty query, add a score for each of the recently executed
+    // commands, which are displayed before all other items. The score
+    // reflects the recency of the item, so that sorting the scores
+    // preserves the order of execution.
+    if (!query) {
+      for (let i = 0, n = recentItems.length; i < n; ++i) {
+        scores.push({
+          matchType: MatchType.Recent,
+          categoryIndices: null,
+          labelIndices: null,
+          score: i,
+          item: recentItems[i]
+        });
+      }
+    }
 
     // Iterate over the items and match against the query.
     for (let i = 0, n = items.length; i < n; ++i) {
@@ -1188,15 +1386,18 @@ namespace Private {
         continue;
       }
 
-      // If the query is empty, all items are matched by default.
+      // If the query is empty, all items are matched by default, except
+      // for the recently executed commands which are already scored.
       if (!query) {
-        scores.push({
-          matchType: MatchType.Default,
-          categoryIndices: null,
-          labelIndices: null,
-          score: 0,
-          item
-        });
+        if (recentItems.indexOf(item) === -1) {
+          scores.push({
+            matchType: MatchType.Default,
+            categoryIndices: null,
+            labelIndices: null,
+            score: 0,
+            item
+          });
+        }
         continue;
       }
 
@@ -1375,26 +1576,48 @@ namespace Private {
   /**
    * Create the results from an array of sorted scores.
    */
-  function createResults(scores: IScore[]): SearchResult[] {
+  function createResults(
+    scores: IScore[],
+    recentItems: CommandPalette.IItem[]
+  ): SearchResult[] {
     // Set up the search results array.
     let results: SearchResult[] = [];
 
     // Iterate over each score in the array.
     for (let i = 0, n = scores.length; i < n; ++i) {
       // Extract the current item and indices.
-      let { item, categoryIndices, labelIndices } = scores[i];
+      let { matchType, item, categoryIndices, labelIndices } = scores[i];
+
+      // Look up whether the item is a recently executed command.
+      let recent = recentItems.indexOf(item) !== -1;
+
+      // Handle the recently executed commands for an empty query, which
+      // sort before all other results and are displayed without a
+      // category header.
+      if (matchType === MatchType.Recent) {
+        // Create the item result for the score.
+        results.push({ type: 'item', item, indices: labelIndices, recent });
+        continue;
+      }
 
       // Extract the category for the current item.
       let category = item.category;
 
+      // Look up the preceding search result, if any.
+      let prev = i === 0 ? null : scores[i - 1];
+
       // Is this the same category as the preceding result?
-      if (i === 0 || category !== scores[i - 1].item.category) {
+      if (
+        !prev ||
+        prev.matchType === MatchType.Recent ||
+        category !== prev.item.category
+      ) {
         // Add the header result for the category.
         results.push({ type: 'header', category, indices: categoryIndices });
       }
 
       // Create the item result for the score.
-      results.push({ type: 'item', item, indices: labelIndices });
+      results.push({ type: 'item', item, indices: labelIndices, recent });
     }
 
     // Return the final results.

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -115,6 +115,278 @@ describe('@lumino/widgets', () => {
       });
     });
 
+    describe('#maxRecentCommands', () => {
+      it('should default to `0`', () => {
+        expect(palette.maxRecentCommands).to.equal(0);
+      });
+
+      it('should be initialized from the palette options', () => {
+        let palette = new CommandPalette({ commands, maxRecentCommands: 5 });
+        expect(palette.maxRecentCommands).to.equal(5);
+        palette.dispose();
+      });
+
+      it('should normalize invalid values', () => {
+        palette.maxRecentCommands = 2.7;
+        expect(palette.maxRecentCommands).to.equal(2);
+        palette.maxRecentCommands = -1;
+        expect(palette.maxRecentCommands).to.equal(0);
+        palette.maxRecentCommands = NaN;
+        expect(palette.maxRecentCommands).to.equal(0);
+      });
+
+      context('recent commands', () => {
+        let visibleFlag = true;
+
+        const executeItem = (label: string): void => {
+          MessageLoop.flush();
+          let labels = Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
+          );
+          let labelNode = labels.find(node => node.textContent === label)!;
+          let itemNode = labelNode.closest('.lm-CommandPalette-item')!;
+          itemNode.dispatchEvent(new MouseEvent('click', { bubbles }));
+          MessageLoop.flush();
+        };
+
+        const headerLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-header')
+          ).map(node => node.textContent);
+        };
+
+        const itemLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
+          ).map(node => node.textContent);
+        };
+
+        const recentLabels = (): (string | null)[] => {
+          MessageLoop.flush();
+          return Array.from(
+            palette.contentNode.querySelectorAll(
+              '.lm-CommandPalette-item.lm-mod-recent .lm-CommandPalette-itemLabel'
+            )
+          ).map(node => node.textContent);
+        };
+
+        beforeEach(() => {
+          visibleFlag = true;
+          palette.maxRecentCommands = 3;
+          ['One', 'Two', 'Three', 'Four'].forEach(label => {
+            let command = `test:${label.toLowerCase()}`;
+            commands.addCommand(command, { execute: () => {}, label });
+            palette.addItem({ command, category: 'Numbers' });
+          });
+          commands.addCommand('test:hidden', {
+            execute: () => {},
+            isVisible: () => visibleFlag,
+            label: 'Hidden'
+          });
+          palette.addItem({ command: 'test:hidden', category: 'Numbers' });
+        });
+
+        it('should display the recently executed commands at the top', () => {
+          expect(recentLabels()).to.deep.equal([]);
+          executeItem('Two');
+          expect(recentLabels()).to.deep.equal(['Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Two',
+            'Four',
+            'Hidden',
+            'One',
+            'Three'
+          ]);
+          // The recent items are displayed before the category headers.
+          expect(headerLabels()).to.deep.equal(['Numbers']);
+          let first = palette.contentNode.firstElementChild!;
+          expect(first.classList.contains('lm-CommandPalette-item')).to.equal(
+            true
+          );
+          expect(first.classList.contains('lm-mod-recent')).to.equal(true);
+        });
+
+        it('should navigate and execute the recent commands with the keyboard', () => {
+          executeItem('Three');
+          executeItem('One');
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 40 // Down Arrow
+            })
+          );
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 40 // Down Arrow
+            })
+          );
+          MessageLoop.flush();
+          let active = palette.contentNode.querySelector(
+            '.lm-CommandPalette-item.lm-mod-active'
+          )!;
+          expect(
+            active.querySelector('.lm-CommandPalette-itemLabel')!.textContent
+          ).to.equal('Three');
+          palette.node.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              bubbles,
+              keyCode: 13 // Enter
+            })
+          );
+          expect(recentLabels()).to.deep.equal(['Three', 'One']);
+        });
+
+        it('should order the recently executed commands by recency', () => {
+          executeItem('Three');
+          executeItem('One');
+          expect(recentLabels()).to.deep.equal(['One', 'Three']);
+          expect(itemLabels()).to.deep.equal([
+            'One',
+            'Three',
+            'Four',
+            'Hidden',
+            'Two'
+          ]);
+          executeItem('Three');
+          expect(recentLabels()).to.deep.equal(['Three', 'One']);
+          expect(itemLabels()).to.deep.equal([
+            'Three',
+            'One',
+            'Four',
+            'Hidden',
+            'Two'
+          ]);
+        });
+
+        it('should drop the oldest command when the history is full', () => {
+          executeItem('One');
+          executeItem('Two');
+          executeItem('Three');
+          executeItem('Four');
+          expect(recentLabels()).to.deep.equal(['Four', 'Three', 'Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Four',
+            'Three',
+            'Two',
+            'Hidden',
+            'One'
+          ]);
+        });
+
+        it('should track items with distinct arguments separately', () => {
+          commands.addCommand('test:args', {
+            execute: () => {},
+            label: args => `Arg ${args.n}`
+          });
+          palette.addItem({
+            command: 'test:args',
+            args: { n: 1 },
+            category: 'Numbers'
+          });
+          palette.addItem({
+            command: 'test:args',
+            args: { n: 2 },
+            category: 'Numbers'
+          });
+          executeItem('Arg 1');
+          executeItem('Arg 2');
+          expect(recentLabels()).to.deep.equal(['Arg 2', 'Arg 1']);
+        });
+
+        it('should mark the recently executed commands when searching', () => {
+          executeItem('Four');
+          expect(recentLabels()).to.deep.equal(['Four']);
+          palette.inputNode.value = 'four';
+          palette.refresh();
+          expect(headerLabels()).to.deep.equal(['Numbers']);
+          expect(itemLabels()).to.deep.equal(['Four']);
+          expect(recentLabels()).to.deep.equal(['Four']);
+          palette.inputNode.value = 'three';
+          palette.refresh();
+          expect(itemLabels()).to.deep.equal(['Three']);
+          expect(recentLabels()).to.deep.equal([]);
+        });
+
+        it('should not change the order of the search results', () => {
+          executeItem('Two');
+          palette.inputNode.value = 't';
+          palette.refresh();
+          expect(itemLabels()).to.deep.equal(['Three', 'Two']);
+          expect(recentLabels()).to.deep.equal(['Two']);
+        });
+
+        it('should drop the oldest commands when the limit is lowered', () => {
+          executeItem('One');
+          executeItem('Two');
+          palette.maxRecentCommands = 1;
+          expect(recentLabels()).to.deep.equal(['Two']);
+          expect(itemLabels()).to.deep.equal([
+            'Two',
+            'Four',
+            'Hidden',
+            'One',
+            'Three'
+          ]);
+        });
+
+        it('should clear and disable the history when set to `0`', () => {
+          executeItem('One');
+          expect(recentLabels()).to.deep.equal(['One']);
+          palette.maxRecentCommands = 0;
+          expect(recentLabels()).to.deep.equal([]);
+          palette.maxRecentCommands = 3;
+          expect(recentLabels()).to.deep.equal([]);
+        });
+
+        it('should not display commands which were removed', () => {
+          executeItem('One');
+          palette.removeItemAt(0);
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal([
+            'Four',
+            'Hidden',
+            'Three',
+            'Two'
+          ]);
+        });
+
+        it('should not display commands which are not visible', () => {
+          executeItem('Hidden');
+          expect(recentLabels()).to.deep.equal(['Hidden']);
+          visibleFlag = false;
+          palette.refresh();
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal(['Four', 'One', 'Three', 'Two']);
+        });
+
+        it('should not display commands which are disabled', () => {
+          let enabled = true;
+          commands.addCommand('test:enabled', {
+            execute: () => {},
+            isEnabled: () => enabled,
+            label: 'Enabled'
+          });
+          palette.addItem({ command: 'test:enabled', category: 'Numbers' });
+          executeItem('Enabled');
+          expect(recentLabels()).to.deep.equal(['Enabled']);
+          enabled = false;
+          palette.refresh();
+          expect(recentLabels()).to.deep.equal([]);
+          expect(itemLabels()).to.deep.equal([
+            'Enabled',
+            'Four',
+            'Hidden',
+            'One',
+            'Three',
+            'Two'
+          ]);
+        });
+      });
+    });
+
     describe('#addItems()', () => {
       it('should add items to a command palette using options', () => {
         const item = {
@@ -300,6 +572,31 @@ describe('@lumino/widgets', () => {
         expect(palette.items.length).to.equal(2);
         palette.clearItems();
         expect(palette.items.length).to.equal(0);
+      });
+    });
+
+    describe('#clearRecentCommands()', () => {
+      it('should clear the recently executed commands', () => {
+        palette.maxRecentCommands = 3;
+        commands.addCommand('test', { execute: () => {}, label: 'test' });
+        palette.addItem(defaultOptions);
+        MessageLoop.flush();
+
+        let recents = () =>
+          palette.contentNode.querySelectorAll(
+            '.lm-CommandPalette-item.lm-mod-recent'
+          );
+        let item = palette.contentNode.querySelector(
+          '.lm-CommandPalette-item'
+        )!;
+
+        item.dispatchEvent(new MouseEvent('click', { bubbles }));
+        MessageLoop.flush();
+        expect(recents()).to.have.length(1);
+
+        palette.clearRecentCommands();
+        MessageLoop.flush();
+        expect(recents()).to.have.length(0);
       });
     });
 
@@ -928,6 +1225,17 @@ describe('@lumino/widgets', () => {
           let node = VirtualDOM.realize(vNode);
           expect(node.classList.contains('lm-mod-active')).to.equal(true);
         });
+
+        it('should handle the recent state', () => {
+          let vNode = renderer.renderItem({
+            item,
+            indices: null,
+            active: false,
+            recent: true
+          });
+          let node = VirtualDOM.realize(vNode);
+          expect(node.classList.contains('lm-mod-recent')).to.equal(true);
+        });
       });
 
       describe('#renderEmptyMessage()', () => {
@@ -1007,10 +1315,11 @@ describe('@lumino/widgets', () => {
           let name = renderer.createItemClass({
             item,
             indices: null,
-            active: true
+            active: true,
+            recent: true
           });
           let expected =
-            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active testClass';
+            'lm-CommandPalette-item lm-mod-disabled lm-mod-toggled lm-mod-active lm-mod-recent testClass';
           expect(name).to.equal(expected);
         });
       });

--- a/packages/widgets/tests/src/commandpalette.spec.ts
+++ b/packages/widgets/tests/src/commandpalette.spec.ts
@@ -138,33 +138,56 @@ describe('@lumino/widgets', () => {
       context('recent commands', () => {
         let visibleFlag = true;
 
+        // TEMP-INSTRUMENTATION: remove before committing.
+        const __timed = <T>(name: string, fn: () => T): T => {
+          const t0 = performance.now();
+          const result = fn();
+          const d = performance.now() - t0;
+          if (d > 100) {
+            console.log(`SLOWOP ${name}: ${Math.round(d)}ms`);
+          }
+          return result;
+        };
+
         const executeItem = (label: string): void => {
+          const t0 = performance.now();
           MessageLoop.flush();
+          const t1 = performance.now();
           let labels = Array.from(
             palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
           );
           let labelNode = labels.find(node => node.textContent === label)!;
           let itemNode = labelNode.closest('.lm-CommandPalette-item')!;
+          const t2 = performance.now();
           itemNode.dispatchEvent(new MouseEvent('click', { bubbles }));
+          const t3 = performance.now();
           MessageLoop.flush();
+          const t4 = performance.now();
+          if (t4 - t0 > 100) {
+            console.log(
+              `SLOWOP executeItem(${label}): total=${Math.round(t4 - t0)}ms ` +
+                `flush1=${Math.round(t1 - t0)} query=${Math.round(t2 - t1)} ` +
+                `click=${Math.round(t3 - t2)} flush2=${Math.round(t4 - t3)}`
+            );
+          }
         };
 
         const headerLabels = (): (string | null)[] => {
-          MessageLoop.flush();
+          __timed('headerLabels.flush', () => MessageLoop.flush());
           return Array.from(
             palette.contentNode.querySelectorAll('.lm-CommandPalette-header')
           ).map(node => node.textContent);
         };
 
         const itemLabels = (): (string | null)[] => {
-          MessageLoop.flush();
+          __timed('itemLabels.flush', () => MessageLoop.flush());
           return Array.from(
             palette.contentNode.querySelectorAll('.lm-CommandPalette-itemLabel')
           ).map(node => node.textContent);
         };
 
         const recentLabels = (): (string | null)[] => {
-          MessageLoop.flush();
+          __timed('recentLabels.flush', () => MessageLoop.flush());
           return Array.from(
             palette.contentNode.querySelectorAll(
               '.lm-CommandPalette-item.lm-mod-recent .lm-CommandPalette-itemLabel'

--- a/packages/widgets/tests/src/index.spec.ts
+++ b/packages/widgets/tests/src/index.spec.ts
@@ -9,6 +9,28 @@
 |----------------------------------------------------------------------------*/
 import '@lumino/widgets/style/index.css';
 
+// TEMP-INSTRUMENTATION: remove before committing. These root-level hooks
+// wrap every test in the bundle: they log tests whose full runnable window
+// (all hooks + body) exceeds 100ms, and gaps between runnables over 100ms.
+let __tStart = 0;
+let __tPrevEnd = 0;
+beforeEach(function () {
+  __tStart = performance.now();
+  const gap = __tStart - __tPrevEnd;
+  if (__tPrevEnd > 0 && gap > 100) {
+    console.log(
+      `SLOWGAP ${Math.round(gap)}ms before: ${this.currentTest?.fullTitle()}`
+    );
+  }
+});
+afterEach(function () {
+  __tPrevEnd = performance.now();
+  const d = __tPrevEnd - __tStart;
+  if (d > 100) {
+    console.log(`SLOWTEST ${Math.round(d)}ms: ${this.currentTest?.fullTitle()}`);
+  }
+});
+
 import './accordionlayout.spec';
 import './accordionpanel.spec';
 import './boxengine.spec';

--- a/packages/widgets/web-test-runner.config.js
+++ b/packages/widgets/web-test-runner.config.js
@@ -7,7 +7,11 @@ module.exports = {
   testFramework: {
     config: {
       forbidOnly: process.env.CI ? true : false,
-      forbidPending: process.env.CI ? true : false
+      forbidPending: process.env.CI ? true : false,
+      // Mocha flags any test exceeding the timeout as a failure, including
+      // synchronous tests measured by wall-clock time, which multi-second
+      // stalls on busy CI runners can push past the default of 2 seconds.
+      timeout: 10000
     }
   }
 };

--- a/review/api/widgets.api.md
+++ b/review/api/widgets.api.md
@@ -174,12 +174,15 @@ export class CommandPalette extends Widget {
     addItem(options: CommandPalette.IItemOptions): CommandPalette.IItem;
     addItems(items: CommandPalette.IItemOptions[]): CommandPalette.IItem[];
     clearItems(): void;
+    clearRecentCommands(): void;
     readonly commands: CommandRegistry;
     get contentNode(): HTMLUListElement;
     dispose(): void;
     handleEvent(event: Event): void;
     get inputNode(): HTMLInputElement;
     get items(): ReadonlyArray<CommandPalette.IItem>;
+    get maxRecentCommands(): number;
+    set maxRecentCommands(value: number);
     protected onActivateRequest(msg: Message): void;
     protected onAfterDetach(msg: Message): void;
     protected onAfterShow(msg: Message): void;
@@ -229,9 +232,11 @@ export namespace CommandPalette {
         readonly active: boolean;
         readonly indices: ReadonlyArray<number> | null;
         readonly item: IItem;
+        readonly recent?: boolean;
     }
     export interface IOptions {
         commands: CommandRegistry;
+        maxRecentCommands?: number;
         renderer?: IRenderer;
     }
     export interface IRenderer {


### PR DESCRIPTION
Throwaway fork-internal PR to collect per-test timing logs for the windows/chromium slowdown seen on jupyterlab/lumino#836. Will be closed and the branch deleted after diagnosis.